### PR TITLE
Add option to disable saying "seconds" after the number of seconds

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -22,6 +22,7 @@ const defaultConfig = {
     "00:30",
     "00:15",
   ],
+  saySeconds: true,
   countdownWhen: 5,
   readPlayer1: false,
   readPlayer2: false,

--- a/chrome/content-script.js
+++ b/chrome/content-script.js
@@ -582,10 +582,14 @@
       ) {
         const minText =
           min > 0 ? `${min} ${getIntl(config.lang).min(min)},` : "";
-        const secText =
-          sec > 0 ? `${sec} ${getIntl(config.lang).sec(sec)}` : "";
+        let secText = "";
+        if (sec > 0) {
+          secText = `${sec}`;
+          if (config.saySeconds) {
+            secText += ` ${getIntl(config.lang).sec(sec)}`;
+          }
+        }
         const text = `${minText} ${secText}`;
-
         say(text, voices);
       }
 
@@ -664,6 +668,7 @@
       "readPlayer1",
       "readPlayer2",
       "readTime",
+      "saySeconds",
     ],
     (data) => {
       config = data;

--- a/chrome/popup/popup.html
+++ b/chrome/popup/popup.html
@@ -104,6 +104,10 @@
         </div>
         <textarea name="moments" id="moments" rows="6"></textarea>
       </div>
+      <div class="alerts__options">
+        <input type="checkbox" id="say-seconds"/>
+        <label for="say-seconds">Say "seconds" after the number of seconds</label>
+      </div>
     </div>
     <div class="shortcuts">
       <p class="shortcuts__title">In-game keyboard shortcuts:</p>

--- a/chrome/popup/popup.js
+++ b/chrome/popup/popup.js
@@ -13,6 +13,7 @@ const main = () => {
   const $readTime = document.getElementById("read-time");
   const $tabsBox = document.getElementById("tabs");
   const $tabs = document.querySelectorAll("#tabs button");
+  const $saySeconds = document.getElementById("say-seconds");
 
   const voices = speechSynthesis.getVoices();
   const defaultVoice = voices.find((item) => (item.lang = "en-US"));
@@ -50,6 +51,7 @@ const main = () => {
       "readPlayer2",
       "readTime",
       "tab",
+      "saySeconds",
     ],
     (config) => {
       tab = config.tab;
@@ -64,6 +66,7 @@ const main = () => {
       $readPlayer1.checked = config.readPlayer1;
       $readPlayer2.checked = config.readPlayer2;
       $readTime.checked = config.readTime;
+      $saySeconds.checked = config.saySeconds;
 
       if (config.readTime) {
         $readTime.classList.add("read__toggle--active");
@@ -198,6 +201,10 @@ const main = () => {
         $moments.value = config[momentsName].join("\n");
       });
     }
+  });
+
+  $saySeconds.addEventListener("change", () => {
+    chrome.storage.sync.set({ saySeconds: $saySeconds.checked });
   });
 };
 

--- a/chrome/popup/styles.css
+++ b/chrome/popup/styles.css
@@ -345,6 +345,7 @@ textarea {
   border-top: solid 1px #999;
   padding: 10px 15px;
   display: flex;
+  flex-flow: wrap;
 }
 
 .alerts__title,
@@ -375,6 +376,18 @@ textarea {
 .alerts__setup {
   position: relative;
   width: 120px;
+}
+
+.alerts__options {
+  display: flex;
+  align-items: center;
+  flex-basis: 100%;
+  margin-top: 5px;
+  font-size: 1.2rem;
+}
+
+.alerts__options > input[type="checkbox"] {
+  margin-right: 5px;
 }
 
 .alerts li {


### PR DESCRIPTION
For brevity and to minimize distraction, some users may prefer to just hear, for example "45" instead of "45 seconds". This PR adds an option for that.
